### PR TITLE
Config tweaks for UX

### DIFF
--- a/config/ConEmu.xml
+++ b/config/ConEmu.xml
@@ -628,7 +628,7 @@
 			<value name="StatusBar.Hide.Dpi" type="hex" data="01"/>
 			<value name="TabFlashChanged" type="dword" data="00000008"/>
 			<value name="TabModifiedSuffix" type="string" data="[*]"/>
-			<key name="HotKeys" modified="2015-05-17 22:10:27" build="150513">
+			<key name="HotKeys" modified="2015-09-30 19:27:37" build="150913">
 				<value name="KeyMacroVersion" type="hex" data="02"/>
 				<value name="Multi.Modifier" type="dword" data="00000011"/>
 				<value name="Multi.ArrowsModifier" type="dword" data="0000005b"/>
@@ -648,8 +648,8 @@
 				<value name="Multi.NewConsolePopup" type="dword" data="00000000"/>
 				<value name="Multi.NewConsolePopup2" type="dword" data="00000000"/>
 				<value name="Multi.NewAttach" type="dword" data="00000000"/>
-				<value name="Multi.NewSplitV" type="dword" data="00000000"/>
-				<value name="Multi.NewSplitH" type="dword" data="00000000"/>
+				<value name="Multi.NewSplitV" type="dword" data="00101128"/>
+				<value name="Multi.NewSplitH" type="dword" data="00101127"/>
 				<value name="Multi.SplitMaximize" type="dword" data="00005d0d"/>
 				<value name="Multi.SplitSizeVU" type="dword" data="00105d26"/>
 				<value name="Multi.SplitSizeVD" type="dword" data="00105d28"/>
@@ -708,7 +708,7 @@
 				<value name="TransparencyDec" type="dword" data="00000000"/>
 				<value name="Key.TabMenu" type="dword" data="00000000"/>
 				<value name="Key.TabMenu2" type="dword" data="00000000"/>
-				<value name="Key.Maximize" type="dword" data="00000000"/>
+				<value name="Key.Maximize" type="dword" data="8080807a"/>
 				<value name="Key.MaximizeWidth" type="dword" data="00000000"/>
 				<value name="Key.MaximizeHeight" type="dword" data="00000000"/>
 				<value name="Key.TileToLeft" type="dword" data="00000000"/>
@@ -720,8 +720,8 @@
 				<value name="Key.SysMenu2" type="dword" data="00001102"/>
 				<value name="Key.BufUp" type="dword" data="00001126"/>
 				<value name="Key.BufDn" type="dword" data="00001128"/>
-				<value name="Key.BufPgUp" type="dword" data="00001121"/>
-				<value name="Key.BufPgDn" type="dword" data="00001122"/>
+				<value name="Key.BufPgUp" type="dword" data="80808021"/>
+				<value name="Key.BufPgDn" type="dword" data="80808022"/>
 				<value name="Key.BufHfPgUp" type="dword" data="00005d21"/>
 				<value name="Key.BufHfPgDn" type="dword" data="00005d22"/>
 				<value name="Key.BufTop" type="dword" data="00005d24"/>
@@ -743,10 +743,10 @@
 				<value name="KeyMacro04.Text" type="string" data="FontSetSize(1,-2)"/>
 				<value name="KeyMacro05" type="dword" data="00a01233"/>
 				<value name="KeyMacro05.Text" type="string" data="Task(&quot;PowerShell as Admin&quot;)"/>
-				<value name="KeyMacro06" type="dword" data="00000000"/>
-				<value name="KeyMacro06.Text" type="string" data=""/>
-				<value name="KeyMacro07" type="dword" data="00000000"/>
-				<value name="KeyMacro07.Text" type="string" data=""/>
+				<value name="KeyMacro06" type="dword" data="00001026"/>
+				<value name="KeyMacro06.Text" type="string" data="Print(&quot;pushd ..\n&quot;)"/>
+				<value name="KeyMacro07" type="dword" data="00001028"/>
+				<value name="KeyMacro07.Text" type="string" data="Print(&quot;popd\n&quot;)"/>
 				<value name="KeyMacro08" type="dword" data="00000000"/>
 				<value name="KeyMacro08.Text" type="string" data=""/>
 				<value name="KeyMacro09" type="dword" data="00000000"/>
@@ -805,6 +805,7 @@
 				<value name="DndLKey" type="hex" data="00"/>
 				<value name="DndRKey" type="hex" data="a2"/>
 				<value name="WndDragKey" type="dword" data="00121101"/>
+				<value name="Multi.Unfasten" type="dword" data="00000000"/>
 			</key>
 		</key>
 	</key>

--- a/config/ConEmu.xml
+++ b/config/ConEmu.xml
@@ -483,9 +483,9 @@
 			<value name="DndLKey" type="hex" data="00"/>
 			<value name="DndRKey" type="hex" data="a2"/>
 			<value name="WndDragKey" type="dword" data="00121101"/>
-			<key name="Tasks" modified="2015-05-17 22:10:27" build="150513">
+			<key name="Tasks" modified="2015-09-30 19:43:33" build="150913">
 				<value name="Count" type="dword" data="00000003"/>
-				<key name="Task1" modified="2015-05-17 22:10:27" build="150513">
+				<key name="Task1" modified="2015-09-30 19:43:33" build="150913">
 					<value name="Name" type="string" data="{cmd}"/>
 					<value name="GuiArgs" type="string" data="/icon &quot;%CMDER_ROOT%\cmder.exe&quot;"/>
 					<value name="Cmd1" type="string" data="cmd /k &quot;%ConEmuDir%\..\init.bat&quot;  -new_console:d:%USERPROFILE%"/>
@@ -494,7 +494,7 @@
 					<value name="Hotkey" type="dword" data="00000000"/>
 					<value name="Flags" type="dword" data="00000000"/>
 				</key>
-				<key name="Task2" modified="2015-05-17 22:10:27" build="150513">
+				<key name="Task2" modified="2015-09-30 19:43:33" build="150913">
 					<value name="Name" type="string" data="{PowerShell}"/>
 					<value name="GuiArgs" type="string" data="/icon &quot;%CMDER_ROOT%\cmder.exe&quot;"/>
 					<value name="Cmd1" type="string" data="PowerShell -ExecutionPolicy Bypass -NoLogo -NoProfile -NoExit -Command &quot;Invoke-Expression '. ''%ConEmuDir%\..\profile.ps1'''&quot; -new_console:d:&quot;%USERPROFILE%&quot;"/>
@@ -503,7 +503,7 @@
 					<value name="Hotkey" type="dword" data="00000000"/>
 					<value name="Flags" type="dword" data="00000000"/>
 				</key>
-				<key name="Task3" modified="2015-05-17 22:10:27" build="150513">
+				<key name="Task3" modified="2015-09-30 19:43:33" build="150913">
 					<value name="Name" type="string" data="{PowerShell as Admin}"/>
 					<value name="Hotkey" type="dword" data="00000000"/>
 					<value name="GuiArgs" type="string" data="/icon &quot;%CMDER_ROOT%\cmder.exe&quot;"/>
@@ -523,11 +523,11 @@
 				</key>
 			</key>
 
-			<key name="Apps" modified="2015-05-17 22:10:27" build="150513">
+			<key name="Apps" modified="2015-09-30 19:43:33" build="150913">
 				<value name="Count" type="dword" data="00000000"/>
 			</key>
-			<key name="Colors" modified="2015-05-17 22:10:27" build="150513">
-				<key name="Palette1" modified="2015-05-17 22:10:27" build="150513">
+			<key name="Colors" modified="2015-09-30 19:43:33" build="150913">
+				<key name="Palette1" modified="2015-09-30 19:43:33" build="150913">
 					<value name="Name" type="string" data="Monokai"/>
 					<value name="ExtendColors" type="hex" data="00"/>
 					<value name="ExtendColorIdx" type="hex" data="0e"/>
@@ -628,7 +628,7 @@
 			<value name="StatusBar.Hide.Dpi" type="hex" data="01"/>
 			<value name="TabFlashChanged" type="dword" data="00000008"/>
 			<value name="TabModifiedSuffix" type="string" data="[*]"/>
-			<key name="HotKeys" modified="2015-09-30 19:27:37" build="150913">
+			<key name="HotKeys" modified="2015-09-30 19:43:33" build="150913">
 				<value name="KeyMacroVersion" type="hex" data="02"/>
 				<value name="Multi.Modifier" type="dword" data="00000011"/>
 				<value name="Multi.ArrowsModifier" type="dword" data="0000005b"/>
@@ -720,8 +720,8 @@
 				<value name="Key.SysMenu2" type="dword" data="00001102"/>
 				<value name="Key.BufUp" type="dword" data="00001126"/>
 				<value name="Key.BufDn" type="dword" data="00001128"/>
-				<value name="Key.BufPgUp" type="dword" data="80808021"/>
-				<value name="Key.BufPgDn" type="dword" data="80808022"/>
+				<value name="Key.BufPgUp" type="dword" data="00001121"/>
+				<value name="Key.BufPgDn" type="dword" data="00001122"/>
 				<value name="Key.BufHfPgUp" type="dword" data="00005d21"/>
 				<value name="Key.BufHfPgDn" type="dword" data="00005d22"/>
 				<value name="Key.BufTop" type="dword" data="00005d24"/>
@@ -807,6 +807,13 @@
 				<value name="WndDragKey" type="dword" data="00121101"/>
 				<value name="Multi.Unfasten" type="dword" data="00000000"/>
 			</key>
+			<value name="StartCreateDelay" type="dword" data="00000064"/>
+			<value name="DefaultTerminalDebugLog" type="hex" data="00"/>
+			<value name="Restore2ActiveMon" type="hex" data="00"/>
+			<value name="DownShowExOnTopMessage" type="hex" data="00"/>
+			<value name="EnvironmentSet" type="multi"/>
+			<value name="Update.InetTool" type="hex" data="00"/>
+			<value name="Update.InetToolCmd" type="string" data=""/>
 		</key>
 	</key>
 </key>

--- a/config/ConEmu.xml
+++ b/config/ConEmu.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <key name="Software">
 	<key name="ConEmu">
-		<key name=".Vanilla" modified="2015-05-17 22:10:27" build="150513">
+		<key name=".Vanilla" modified="2015-09-30 19:27:40" build="150913">
 			<value name="ColorTable00" type="dword" data="00222827"/>
 			<value name="ColorTable01" type="dword" data="009e5401"/>
 			<value name="ColorTable02" type="dword" data="0004aa74"/>
@@ -56,7 +56,7 @@
 			<value name="ClipboardClickPromptPosition" type="hex" data="00"/>
 			<value name="ClipboardDeleteLeftWord" type="hex" data="01"/>
 			<value name="TrueColorerSupport" type="hex" data="01"/>
-			<value name="FadeInactive" type="hex" data="01"/>
+			<value name="FadeInactive" type="hex" data="00"/>
 			<value name="FadeInactiveLow" type="hex" data="00"/>
 			<value name="FadeInactiveHigh" type="hex" data="c8"/>
 			<value name="ConVisible" type="hex" data="00"/>
@@ -116,21 +116,21 @@
 			<value name="bgImageColors" type="dword" data="ffffffff"/>
 			<value name="bgOperation" type="hex" data="00"/>
 			<value name="bgPluginAllowed" type="hex" data="01"/>
-			<value name="AlphaValue" type="hex" data="f8"/>
-			<value name="AlphaValueSeparate" type="hex" data="01"/>
+			<value name="AlphaValue" type="hex" data="ff"/>
+			<value name="AlphaValueSeparate" type="hex" data="00"/>
 			<value name="AlphaValueInactive" type="hex" data="ee"/>
 			<value name="UserScreenTransparent" type="hex" data="00"/>
 			<value name="ColorKeyTransparent" type="hex" data="00"/>
 			<value name="ColorKeyValue" type="dword" data="00010101"/>
 			<value name="UseCurrentSizePos" type="hex" data="01"/>
-			<value name="WindowMode" type="dword" data="0000051f"/>
-			<value name="ConWnd Width" type="dword" data="0000006f"/>
-			<value name="ConWnd Height" type="dword" data="0000001a"/>
+			<value name="WindowMode" type="dword" data="00000520"/>
+			<value name="ConWnd Width" type="dword" data="00000078"/>
+			<value name="ConWnd Height" type="dword" data="00000028"/>
 			<value name="Cascaded" type="hex" data="01"/>
-			<value name="ConWnd X" type="dword" data="000003f8"/>
-			<value name="ConWnd Y" type="dword" data="00000143"/>
+			<value name="ConWnd X" type="dword" data="00000157"/>
+			<value name="ConWnd Y" type="dword" data="00000006"/>
 			<value name="16bit Height" type="dword" data="00000000"/>
-			<value name="AutoSaveSizePos" type="hex" data="00"/>
+			<value name="AutoSaveSizePos" type="hex" data="01"/>
 			<value name="IntegralSize" type="hex" data="00"/>
 			<value name="QuakeStyle" type="hex" data="00"/>
 			<value name="QuakeAnimation" type="dword" data="0000012c"/>
@@ -145,7 +145,7 @@
 			<value name="ConsoleFontName" type="string" data="Lucida Console"/>
 			<value name="ConsoleFontWidth" type="dword" data="00000003"/>
 			<value name="ConsoleFontHeight" type="dword" data="00000005"/>
-			<value name="DefaultBufferHeight" type="dword" data="000003e8"/>
+			<value name="DefaultBufferHeight" type="dword" data="00001388"/>
 			<value name="AutoBufferHeight" type="hex" data="01"/>
 			<value name="CmdOutputCP" type="dword" data="00000000"/>
 			<value name="ComSpec.Type" type="hex" data="00"/>
@@ -250,7 +250,7 @@
 			<value name="StatusBar.Hide.Title" type="hex" data="01"/>
 			<value name="StatusBar.Hide.Resize" type="hex" data="00"/>
 			<value name="Tabs" type="hex" data="01"/>
-			<value name="TabsLocation" type="hex" data="01"/>
+			<value name="TabsLocation" type="hex" data="00"/>
 			<value name="TabSelf" type="hex" data="01"/>
 			<value name="TabLazy" type="hex" data="01"/>
 			<value name="TabRecent" type="hex" data="01"/>
@@ -288,7 +288,7 @@
 			<value name="DesktopMode" type="hex" data="00"/>
 			<value name="SnapToDesktopEdges" type="hex" data="00"/>
 			<value name="AlwaysOnTop" type="hex" data="00"/>
-			<value name="SleepInBackground" type="hex" data="01"/>
+			<value name="SleepInBackground" type="hex" data="00"/>
 			<value name="MinimizeOnLoseFocus" type="hex" data="00"/>
 			<value name="DisableFarFlashing" type="hex" data="00"/>
 			<value name="DisableAllFlashing" type="hex" data="00"/>


### PR DESCRIPTION
UI config tweaks
* Disable FadeInactive
* Start task set to {cmd}
* Disable console transparency
* Make console bigger by default
* Start maximized
* Save window position & size
* Set buffer height to 5000 (useful when dealing with large log outputs)
* Tabs on top as anywhere in the system
* Disable sleep in backgound

Tweak hotkeys 
* Split horizotally with Ctrl+Right
* Split vertically with Ctrl+Down
* Maximize/restore with F11
* Scroll buffer one page up/down with Ctrl+PgUp/Ctrl+PgDown

Macros for directory navigation. These macros encourage use of pushd/popd
and therefore allow to navigate dir history faster.
* push .. with Ctrl+Up
* popd with Ctrl+Down

Automatic update of dates and conemu build in config